### PR TITLE
fix: Improve SSH host key scanning and connectivity checks in staging…

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -52,7 +52,11 @@ jobs:
             - name: Add host key
               run: |
                   mkdir -p ~/.ssh
-                  ssh-keyscan -H ${{ secrets.HOST }} >> ~/.ssh/known_hosts
+                  echo "Attempting to scan host ${{ secrets.HOST }}"
+                  ssh-keyscan -H ${{ secrets.HOST }} -T 60 >> ~/.ssh/known_hosts || echo "Failed to scan host key"
+                  cat ~/.ssh/known_hosts
+                  echo "Verifying connectivitya to ${{ secrets.HOST }}"
+                  nc -zv ${{ secrets.HOST }} 22 || echo "Cannot connect to port 22"
 
             - name: Deploy to staging server
               run: |


### PR DESCRIPTION
… workflow

- Added verbose logging for SSH host key scanning
- Increased timeout for ssh-keyscan to 60 seconds
- Added fallback error message if host key scanning fails
- Included network connectivity check to port 22
- Enhanced debugging for deployment workflow