### PR TITLE
feat: add release notes functionality with GraphQL integration

### DIFF
--- a/api/src/main.py
+++ b/api/src/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from api.src.v1.release_note.routers import release_notes_router
 from shared.src.core.database import Database
 from shared.src.core.error_handlers import api_error_handler
 from shared.src.core.exceptions import APIException
@@ -90,6 +91,8 @@ def create_app():
     app.include_router(library_router.router, prefix=f"{prefix_v1}/library", tags=["library"])
     app.include_router(map_router.router, prefix=f"{prefix_v1}/map", tags=["map"])
     app.include_router(feature_flags_router.router, prefix=f"{prefix_v1}", tags=["feature-flag"])
+    app.include_router(release_notes_router.router, prefix=f"{prefix_v1}", tags=["release-note"])
+
     # Add middleware to allow CORS (Cross-Origin Resource Sharing)
     app.add_middleware(
         CORSMiddleware,

--- a/api/src/v1/release_note/graphql/release_notes_query.graphql
+++ b/api/src/v1/release_note/graphql/release_notes_query.graphql
@@ -1,0 +1,8 @@
+query GetReleaseNotes($languageCode: String!, $version: String!) {
+    release_notes(filter: { version: { _eq: $version } }) {
+        translations(filter: { languages_code: { code: { _eq: $languageCode } } }) {
+            highlights
+            details
+        }
+    }
+}

--- a/api/src/v1/release_note/models/release_notes_model.py
+++ b/api/src/v1/release_note/models/release_notes_model.py
@@ -1,0 +1,18 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class ReleaseNoteHighlight(BaseModel):
+    emoji: str
+    title: str
+    description: str
+
+
+class ReleaseNoteDetail(BaseModel):
+    title: str
+
+
+class ReleaseNoteResponse(BaseModel):
+    highlights: List[ReleaseNoteHighlight] | None = None
+    details: List[ReleaseNoteDetail] | None = None

--- a/api/src/v1/release_note/routers/release_notes_router.py
+++ b/api/src/v1/release_note/routers/release_notes_router.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from fastapi.params import Query
+
+from api.src.v1.core.language import get_language
+from api.src.v1.release_note.models.release_notes_model import ReleaseNoteResponse
+from api.src.v1.release_note.services.release_notes_service import ReleaseNoteService
+from shared.src.enums.language_enums import LanguageEnum
+
+router = APIRouter()
+
+
+@router.get(
+    "/release-notes",
+    response_model=ReleaseNoteResponse,
+    description="Get all release notes",
+)
+async def get_all_resources(
+    version: str = Query(..., description="The version of the feature flag"),
+    language: LanguageEnum = Depends(get_language),
+):
+    release_note_service = ReleaseNoteService(version, language)
+    release_note = await release_note_service.get_release_note()
+    return release_note

--- a/api/src/v1/release_note/services/release_notes_service.py
+++ b/api/src/v1/release_note/services/release_notes_service.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from api.src.v1.core.flatten_response_util import flatten_response
+from api.src.v1.release_note.models.release_notes_model import ReleaseNoteResponse
+from shared.src.core.settings import get_settings
+from shared.src.services.directus_service import DirectusService
+
+
+class ReleaseNoteService:
+    def __init__(self, version: str, language_code: str):
+        self.version = version
+        self.language_code = language_code
+        self.settings = get_settings()
+        self.directus = DirectusService()
+
+    async def get_release_note(self) -> ReleaseNoteResponse:
+        try:
+            query_path = Path(__file__).parent.parent / "graphql" / "release_notes_query.graphql"
+            response = self.directus.execute_query_file(
+                query_file_path=query_path,
+                variables={"languageCode": self.language_code, "version": self.version},
+            )
+
+            release_note = flatten_response(response)
+            print(release_note)
+            if "release_notes" not in release_note or not release_note["release_notes"]:
+                return ReleaseNoteResponse(highlights=None, details=None)
+
+            release_note = release_note["release_notes"][0]
+            return ReleaseNoteResponse(**release_note)
+        except Exception as e:
+            raise e


### PR DESCRIPTION
- Introduced a new router for release notes to handle requests.
- Added GraphQL query for fetching release notes data.
- Created models for release note responses using Pydantic.
- Implemented a service to manage release note retrieval logic.
- Updated main application to include the new release notes router.