### PR TITLE
feat: use Accept-Language header for language selection

### DIFF
--- a/api/src/v1/university/routers/university_router.py
+++ b/api/src/v1/university/routers/university_router.py
@@ -1,12 +1,8 @@
-from fastapi import APIRouter, Depends
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from shared.src.core.database import get_async_db
+from fastapi import Header, APIRouter
 
 from ..models.university_model import Universities
 from ..models.faculty_model import Faculties
 from ..services.university_service import UniversityService
-
 
 router = APIRouter()
 
@@ -16,9 +12,9 @@ router = APIRouter()
     response_model=Faculties,
     description="Get all faculty titles and names",
 )
-async def get_faculties(languagecode: str = "en-US") -> Faculties:
+async def get_faculties(accept_language: str = Header())-> Faculties:
     """Fetches all faculties with their titles and ids."""
-    university_service = UniversityService(languagecode)
+    university_service = UniversityService(accept_language)
     faculties = await university_service.get_faculties()
     return faculties
 
@@ -28,7 +24,7 @@ async def get_faculties(languagecode: str = "en-US") -> Faculties:
     response_model=Universities,
     description="Get all universities",
 )
-async def get_universities(language_code: str = "en-US") -> Universities:
-    university_service = UniversityService(language_code)
+async def get_universities(accept_language: str = Header()) -> Universities:
+    university_service = UniversityService(accept_language)
     universities = await university_service.get_universities()
     return universities


### PR DESCRIPTION
# Use Accept-Language Header for Language Selection

## Summary
Replace query parameters with standard HTTP `Accept-Language` header for language selection in university and faculty endpoints.

## Changes Made
- Modified `get_faculties` and `get_universities` endpoints to use `Accept-Language` header instead of query parameters
- Removed unused imports (`Depends`, `AsyncSession`, `get_async_db`)
- Updated parameter names to follow HTTP header conventions (`accept_language`)
- Cleaned up code formatting and removed unnecessary blank lines

## Technical Details
- **Before**: Language was passed as query parameter (`?languagecode=en-US`)
- **After**: Language is extracted from standard HTTP `Accept-Language` header
- This follows HTTP standards and matches frontend implementation that already sends `Accept-Language` header

## API Changes
### Endpoints Modified:
- `GET /faculties` - Now uses `Accept-Language` header
- `GET /universities` - Now uses `Accept-Language` header

### Breaking Changes
⚠️ **Breaking Change**: These endpoints no longer accept language via query parameters. Clients must send the `Accept-Language` header.

## Testing
Test the changes with:
```bash
# Test universities endpoint  
curl -H "Accept-Language: en-US" \
     -H "app-version: 1.0.0" \
     -H "user-api-key: test-api-key" \
     http://localhost:8001/v1/universities
```

```bash
# Test faculties with different language
curl -H "Accept-Language: de-DE" \
     -H "app-version: 1.0.0" \
     -H "user-api-key: test-api-key" \
     http://localhost:8001/v1/faculties
```

## Migration Notes
- Frontend already sends `Accept-Language` header, so no frontend changes needed