### PR TITLE
fix: Added language default value and handling en or de in header pro…

### DIFF
--- a/api/src/v1/university/routers/university_router.py
+++ b/api/src/v1/university/routers/university_router.py
@@ -12,9 +12,10 @@ router = APIRouter()
     response_model=Faculties,
     description="Get all faculty titles and names",
 )
-async def get_faculties(accept_language: str = Header())-> Faculties:
+async def get_faculties(accept_language: str = Header("de-DE"))-> Faculties:
     """Fetches all faculties with their titles and ids."""
-    university_service = UniversityService(accept_language)
+    language = map_language(accept_language)
+    university_service = UniversityService(language)
     faculties = await university_service.get_faculties()
     return faculties
 
@@ -24,7 +25,16 @@ async def get_faculties(accept_language: str = Header())-> Faculties:
     response_model=Universities,
     description="Get all universities",
 )
-async def get_universities(accept_language: str = Header()) -> Universities:
-    university_service = UniversityService(accept_language)
+async def get_universities(accept_language: str = Header("de-DE")) -> Universities:
+    language = map_language(accept_language)
+    university_service = UniversityService(language)
     universities = await university_service.get_universities()
     return universities
+
+def map_language(language: str) -> str:
+    if language == "de":
+        return "de-DE"
+    elif language == "en":
+        return "en-US"
+    else:
+        return language


### PR DESCRIPTION
## Fix Language Handling for Faculties and Universities Endpoints

### ✨ Description

This pull request fixes the handling of the `Accept-Language` header in the `/faculties` and `/universities` endpoints. It ensures that language codes are correctly mapped to their respective locales and provides a sensible default (`"de-DE"`) when none is specified.

---

### 🛠 Changes Made

- **Added default `Accept-Language` header**: 
  - `get_faculties` and `get_universities` now default to `"de-DE"` if no header is provided.
- **Introduced `map_language()` utility function**:
  - `"de"` → `"de-DE"`
  - `"en"` → `"en-US"`
  - Other values are passed through unchanged.
- **Updated service initialization**:
  - `UniversityService` now uses the mapped language code instead of the raw header.

---

### ✅ Behavior Example

**Before**:
```http
GET /faculties
Accept-Language: en
```
→ "en" passed to UniversityService

**After**:
```http
GET /faculties
Accept-Language: en
```
→ "en-US" passed to UniversityService


### 📌 Affected Endpoints
```http
GET /faculties
GET /universities
```

