### PR TITLE
feat: shared events for all users

### DIFF
--- a/api/src/v1/calendar/graphql/create_event.graphql
+++ b/api/src/v1/calendar/graphql/create_event.graphql
@@ -10,6 +10,7 @@ mutation CreateCalendarEvent($data: create_calendar_event_input!) {
     event_type
     start_time
     end_time
+    access_scope
     rule {
       id
       frequency

--- a/api/src/v1/calendar/graphql/delete_event.graphql
+++ b/api/src/v1/calendar/graphql/delete_event.graphql
@@ -2,11 +2,12 @@ mutation DeleteCalendarEvent(
   $eventId: ID!, 
   $ruleId: ID! 
 ) {
-  delete_calendar_rule_item(id: $ruleId) {
+  
+  delete_calendar_event_item(id: $eventId) {
     id
   }
-
-  delete_calendar_event_item(id: $eventId) {
+  
+  delete_calendar_rule_item(id: $ruleId) {
     id
   }
 }

--- a/api/src/v1/calendar/graphql/delete_location.graphql
+++ b/api/src/v1/calendar/graphql/delete_location.graphql
@@ -1,6 +1,4 @@
-mutation DeleteCalendarEventLocation( 
-  $locationId: ID!
-) {
+mutation DeleteCalendarEventLocation($locationId: ID!) {
   delete_calendar_location_item(id: $locationId) {
     id
   }

--- a/api/src/v1/calendar/graphql/get_event.graphql
+++ b/api/src/v1/calendar/graphql/get_event.graphql
@@ -10,6 +10,7 @@ query GetCalendarEvents($filter: calendar_event_filter) {
     event_type
     start_time
     end_time
+    access_scope
     rule {
       id
       frequency

--- a/api/src/v1/calendar/graphql/update_event.graphql
+++ b/api/src/v1/calendar/graphql/update_event.graphql
@@ -10,6 +10,7 @@ mutation UpdateCalendarEvent($id: ID!, $data: update_calendar_event_input!) {
     event_type
     start_time
     end_time
+    access_scope
     rule {
       id
       frequency

--- a/api/src/v1/calendar/models/calendar_model.py
+++ b/api/src/v1/calendar/models/calendar_model.py
@@ -22,7 +22,6 @@ class Frequency(str, Enum):
 
 class UpdateType(int, Enum):
     THIS = 0
-    DELETE_THIS = 1
     ALL = 2
     FUTURE = 3
 
@@ -75,7 +74,6 @@ class CalendarRule(BaseModel):
         )
 
 class CalendarException(BaseModel):
-    #deleted: bool
 
     @staticmethod
     def to_json(create_entry: "CalendarCreate", 

--- a/api/src/v1/calendar/models/calendar_model.py
+++ b/api/src/v1/calendar/models/calendar_model.py
@@ -1,16 +1,17 @@
-import uuid
-from uuid import UUID
-from typing import List, Optional
 from datetime import datetime
-from pydantic import BaseModel, RootModel
 from enum import Enum
-from typing import Dict
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, RootModel
+
 
 class EventType(str, Enum): # not complete
     MOVIE = "MOVIE"
     SPORT = "SPORT"
     LECTURE = "LECTURE"
     EXAM = "EXAM"
+    OTHER = "OTHER"
 
 class Frequency(str, Enum):
     ONCE = "ONCE"
@@ -21,8 +22,19 @@ class Frequency(str, Enum):
 
 class UpdateType(int, Enum):
     THIS = 0
-    ALL = 1
-    FUTURE = 2
+    DELETE_THIS = 1
+    ALL = 2
+    FUTURE = 3
+
+class AccessScope(int, Enum):
+    """Controls which user is authorized to see which event. 
+    This is also sometimes useful, for example for debugging 
+    and not all users should see an public event directly."""
+
+    PERSONAL = 0 # event created by a user
+    PUBLIC = 10 # event for all users
+    USER = 50
+    ADMIN = 100
 
 class CalendarLocation(BaseModel):
     address: str
@@ -30,7 +42,7 @@ class CalendarLocation(BaseModel):
     longitude: float
 
     @staticmethod
-    def from_json(json: Dict) -> "CalendarLocation":
+    def from_json(json: dict) -> "CalendarLocation":
         if json is None:
             return None
         
@@ -41,7 +53,7 @@ class CalendarLocation(BaseModel):
         )
     
     @staticmethod
-    def to_json(entry: "CalendarLocation") -> Dict:  
+    def to_json(entry: "CalendarLocation") -> dict:  
         data = {
             "address": entry.address,
             "latitude": entry.latitude,
@@ -51,11 +63,11 @@ class CalendarLocation(BaseModel):
         
 class CalendarRule(BaseModel):
     frequency: Frequency
-    interval: int                  # e.g. every two weeks: repeat_type=WEEKLY, repeat_interval=2
-    until_time: Optional[datetime] # end date for repeat, used when available. Otherwise the REPEAT_LIMIT is used
+    interval: int                  # e.g. every two weeks: frequency=WEEKLY, interval=2
+    until_time: Optional[datetime] # end date for repeat, used when available
 
     @staticmethod
-    def from_json(json: Dict) -> "CalendarRule":
+    def from_json(json: dict) -> "CalendarRule":
         return CalendarRule(
             frequency=json["frequency"],
             interval=json["interval"],
@@ -63,13 +75,14 @@ class CalendarRule(BaseModel):
         )
 
 class CalendarException(BaseModel):
+    #deleted: bool
 
     @staticmethod
     def to_json(create_entry: "CalendarCreate", 
         calendar_event_id: UUID, 
         recurrence_id: int, 
         location_id: Optional[UUID] = None
-        ) -> Dict:
+        ) -> dict:
         
         loc_data = None
         if create_entry.location:
@@ -91,7 +104,7 @@ class CalendarException(BaseModel):
 
 class CalendarCreate(BaseModel):
     """
-    Create a new calendar entry.
+    Create a new calendar event.
     """
 
     title: Optional[str]
@@ -102,13 +115,14 @@ class CalendarCreate(BaseModel):
     start_time: Optional[datetime]
     end_time: Optional[datetime]
     all_day: bool
+    access_scope: AccessScope
 
     @staticmethod
     def to_json(create_entry: "CalendarCreate", 
-        user_id: uuid.UUID, 
-        rule_id: uuid.UUID, 
-        location_id: uuid.UUID
-        ) -> Dict:
+        user_id: UUID, 
+        rule_id: UUID, 
+        location_id: UUID
+        ) -> dict:
 
         rule_dict = {
             "frequency": create_entry.rule.frequency,
@@ -138,24 +152,25 @@ class CalendarCreate(BaseModel):
                 "end_time": create_entry.end_time.isoformat(),
                 "description": create_entry.description,
                 "location": loc_dict,
-                "rule": rule_dict
+                "rule": rule_dict,
+                "access_scope": create_entry.access_scope
         }
 
-class CalendarEntry(CalendarCreate):
+class CalendarEvent(CalendarCreate):
     """
-    Calendar entry.
+    Calendar event.
     """
 
     id: UUID
-    user_id: UUID
+    user_id: Optional[UUID]
     recurrence_id: Optional[int]
     created_at: datetime
     updated_at: datetime
 
     @staticmethod
-    def from_json(json: Dict, 
-        exception_data: Dict = None
-        ) -> "CalendarEntry":
+    def from_json(json: dict, 
+        exception_data: dict = None
+        ) -> "CalendarEvent":
             updated_at = json.get("date_updated") or json.get("date_created")
 
             rule = CalendarRule.from_json(json["rule"])
@@ -171,16 +186,13 @@ class CalendarEntry(CalendarCreate):
             if exception_data:
                 title = exception_data.get("title", title)
                 description = exception_data.get("description", description)
-                location_exc = CalendarLocation.from_json(exception_data.get("location"))
-                if location_exc:
-                    location = location_exc
-
+                location = CalendarLocation.from_json(exception_data.get("location"))
                 start_time = exception_data.get("start_time", start_time)
                 end_time = exception_data.get("end_time", end_time)
                 all_day = exception_data.get("all_day", all_day)
                 recurrence_id = exception_data.get("recurrence_id", recurrence_id)
 
-            return CalendarEntry(
+            return CalendarEvent(
                 id=json["id"],
                 user_id=json.get("user_id"),
                 created_at=json["date_created"],
@@ -194,18 +206,19 @@ class CalendarEntry(CalendarCreate):
                 end_time=end_time,
                 all_day=all_day,
                 recurrence_id=recurrence_id,
+                access_scope=json["access_scope"]
             )
     
     def copy_with_override(self, 
         **overrides
-        ) -> "CalendarEntry":
+        ) -> "CalendarEvent":
         return self.__class__(**{**self.model_dump(), **overrides})
     
 class CalendarEntries(RootModel):
-    root: List[CalendarEntry]
+    root: List[CalendarEvent]
 
     @classmethod
     def from_list(cls, 
-        data: List[CalendarEntry]
+        data: List[CalendarEvent]
         ) -> "CalendarEntries":
         return CalendarEntries(root=data)

--- a/api/src/v1/calendar/routers/calendar_router.py
+++ b/api/src/v1/calendar/routers/calendar_router.py
@@ -1,46 +1,74 @@
 import uuid
 
-from fastapi import APIRouter, Depends
 from typing import Optional
 
-from api.src.v1.core.api_key import APIKey
-from api.src.v1.calendar.models.calendar_model import CalendarCreate, CalendarEntries
+from fastapi import APIRouter, Depends
+
+from api.src.v1.calendar.models.calendar_model import (
+    AccessScope,
+    CalendarCreate,
+    CalendarEntries,
+    EventType,
+    UpdateType,
+)
 from api.src.v1.calendar.services.calendar_service import CalendarService
+from api.src.v1.core.api_key import APIKey
+
 from shared.src.tables import UserTable
 
 router = APIRouter()
 
-@router.post("/calendar-create", response_model=CalendarEntries, description="Create a calendar entry.")
-async def create_calendar_entry(
+TESTID = uuid.UUID("0cc1152e-c8dc-4ffe-995f-e6638b72704f")
+
+@router.post("/calendar-create-user", response_model=CalendarEntries, description="Create a calendar event for an user.")
+async def create_event_user(
     calendar_data: CalendarCreate,
-    user: UserTable = Depends(APIKey.verify_user_api_key)
+    #user: UserTable = Depends(APIKey.verify_user_api_key)
 ):
-    entries = CalendarService().create_entry(user.id, calendar_data)
+    entries = CalendarService().create_event(TESTID, calendar_data)
     return CalendarEntries.from_list(entries)
 
-@router.delete("/calendar-delete/{entry_id}", response_model=bool, description="Delete a calendar entry.")
-async def delete_calendar_entry(
-    entry_id: uuid.UUID
-):
-    return CalendarService().delete_entry(entry_id)
-
-@router.put("/calendar-update", response_model=CalendarEntries, description="Update a calendar entry.")
-async def update_calendar_entry(
+@router.post("/calendar-create-public", response_model=CalendarEntries, description="Create a calendar event for all users.")
+async def create_event_public(
     calendar_data: CalendarCreate,
-    entry_id: uuid.UUID,
+):
+    entries = CalendarService().create_event(None, calendar_data)
+    return CalendarEntries.from_list(entries)
+
+@router.put("/calendar-update", response_model=CalendarEntries, description="Update a calendar event.")
+async def update_event(
+    calendar_data: CalendarCreate,
+    event_id: uuid.UUID,
     recurrence_id: Optional[int] = None,
-    update_type: int = 0,
-    user: UserTable = Depends(APIKey.verify_user_api_key)
+    update_type: UpdateType = UpdateType.THIS,
+    #user: UserTable = Depends(APIKey.verify_user_api_key)
 ):
-    entries = CalendarService().update_entry(user.id, entry_id, recurrence_id, calendar_data, update_type)
+    entries = CalendarService().update_event(TESTID, event_id, recurrence_id, calendar_data, update_type)
     return CalendarEntries.from_list(entries)
 
-@router.get("/calendar-get", response_model=CalendarEntries, description="Get all calendar entries for a user. Optional with a filter.")
-async def get_calendar_entries(
-    event_type: Optional[str] = None,
+@router.put("/calendar-update-public", response_model=CalendarEntries, description="Update a calendar event available for all users.")
+async def update_event(
+    calendar_data: CalendarCreate,
+    event_id: uuid.UUID,
+    recurrence_id: Optional[int] = None,
+    update_type: UpdateType = UpdateType.THIS
+):
+    entries = CalendarService().update_event(None, event_id, recurrence_id, calendar_data, update_type)
+    return CalendarEntries.from_list(entries)
+
+@router.delete("/calendar-delete/{event_id}", response_model=bool, description="Delete a calendar event.")
+async def delete_event(
+    event_id: uuid.UUID
+):
+    return CalendarService().delete_event(event_id)
+
+@router.get("/calendar-get", response_model=CalendarEntries, description="Get all calendar events for a user. Optional with a filter.")
+async def get_events(
+    event_type: Optional[EventType] = None,
     frequency: Optional[str] = None,
     all_day: Optional[bool] = None,
-    user: UserTable = Depends(APIKey.verify_user_api_key)
+    access_scope: AccessScope = AccessScope.USER
+    #user: UserTable = Depends(APIKey.verify_user_api_key)
 ):
-    entries = CalendarService().get_all(user.id, event_type, frequency, all_day)
-    return CalendarEntries.from_list(entries)
+    events = CalendarService().get_all(TESTID, access_scope, event_type, frequency, all_day)
+    return CalendarEntries.from_list(events)

--- a/api/src/v1/calendar/routers/calendar_router.py
+++ b/api/src/v1/calendar/routers/calendar_router.py
@@ -13,7 +13,7 @@ router = APIRouter()
 @router.post("/calendar-create", response_model=CalendarEntries, description="Create a calendar entry.")
 async def create_calendar_entry(
     calendar_data: CalendarCreate,
-    user: UserTable = Depends(APIKey.verify_user_api_key_soft)
+    user: UserTable = Depends(APIKey.verify_user_api_key)
 ):
     entries = CalendarService().create_entry(user.id, calendar_data)
     return CalendarEntries.from_list(entries)
@@ -30,7 +30,7 @@ async def update_calendar_entry(
     entry_id: uuid.UUID,
     recurrence_id: Optional[int] = None,
     update_type: int = 0,
-    user: UserTable = Depends(APIKey.verify_user_api_key_soft)
+    user: UserTable = Depends(APIKey.verify_user_api_key)
 ):
     entries = CalendarService().update_entry(user.id, entry_id, recurrence_id, calendar_data, update_type)
     return CalendarEntries.from_list(entries)
@@ -40,7 +40,7 @@ async def get_calendar_entries(
     event_type: Optional[str] = None,
     frequency: Optional[str] = None,
     all_day: Optional[bool] = None,
-    user: UserTable = Depends(APIKey.verify_user_api_key_soft)
+    user: UserTable = Depends(APIKey.verify_user_api_key)
 ):
     entries = CalendarService().get_all(user.id, event_type, frequency, all_day)
     return CalendarEntries.from_list(entries)

--- a/api/src/v1/calendar/routers/calendar_router.py
+++ b/api/src/v1/calendar/routers/calendar_router.py
@@ -18,14 +18,12 @@ from shared.src.tables import UserTable
 
 router = APIRouter()
 
-TESTID = uuid.UUID("0cc1152e-c8dc-4ffe-995f-e6638b72704f")
-
 @router.post("/calendar-create-user", response_model=CalendarEntries, description="Create a calendar event for an user.")
 async def create_event_user(
     calendar_data: CalendarCreate,
-    #user: UserTable = Depends(APIKey.verify_user_api_key)
+    user: UserTable = Depends(APIKey.verify_user_api_key)
 ):
-    entries = CalendarService().create_event(TESTID, calendar_data)
+    entries = CalendarService().create_event(user.id, calendar_data)
     return CalendarEntries.from_list(entries)
 
 @router.post("/calendar-create-public", response_model=CalendarEntries, description="Create a calendar event for all users.")
@@ -41,9 +39,9 @@ async def update_event(
     event_id: uuid.UUID,
     recurrence_id: Optional[int] = None,
     update_type: UpdateType = UpdateType.THIS,
-    #user: UserTable = Depends(APIKey.verify_user_api_key)
+    user: UserTable = Depends(APIKey.verify_user_api_key)
 ):
-    entries = CalendarService().update_event(TESTID, event_id, recurrence_id, calendar_data, update_type)
+    entries = CalendarService().update_event(user.id, event_id, recurrence_id, calendar_data, update_type)
     return CalendarEntries.from_list(entries)
 
 @router.put("/calendar-update-public", response_model=CalendarEntries, description="Update a calendar event available for all users.")
@@ -67,8 +65,8 @@ async def get_events(
     event_type: Optional[EventType] = None,
     frequency: Optional[str] = None,
     all_day: Optional[bool] = None,
-    access_scope: AccessScope = AccessScope.USER
-    #user: UserTable = Depends(APIKey.verify_user_api_key)
+    access_scope: AccessScope = AccessScope.USER,
+    user: UserTable = Depends(APIKey.verify_user_api_key)
 ):
-    events = CalendarService().get_all(TESTID, access_scope, event_type, frequency, all_day)
+    events = CalendarService().get_all(user.id, access_scope, event_type, frequency, all_day)
     return CalendarEntries.from_list(events)

--- a/api/src/v1/calendar/services/calendar_service.py
+++ b/api/src/v1/calendar/services/calendar_service.py
@@ -278,53 +278,39 @@ class CalendarService:
         
         return self._generate_repeat_events(item)
 
-    def _update_repeat_event(
-        self,
-        event_id: uuid.UUID,
-        update_data: Optional[CalendarCreate],  # None if delete = True
-        recurrence_id: int,
-        delete: bool = False
+    def _update_repeat_event(self,
+        event_id: uuid.UUID,     
+        update_data: CalendarCreate,  
+        recurrence_id: int                 
         ) -> list[CalendarEvent]:
-        """
-        Performs an update to a generated event instance.
-        If `delete` is True, creates or updates an exception marking the instance as deleted.
-        """
+        """Performs an update to a generated event instance. Therefore a new exception is created or the existing one is updated."""
         event = self._get_event_information(event_id, GraphQLFile.kGetEvent, ["calendar_event", 0]) 
         if not event:
             raise DatabaseError(f"Failed to update {event_id}! No information returned!")
 
         exception = self._get_exception_by_id(event.get("exceptions"), recurrence_id)
 
-        if delete:
-            exc_data = {
-                "recurrence_id": recurrence_id,
-                "event": { "id": str(event_id) },
-                "deleted": True 
+        if exception:
+            file = GraphQLFile.kUpdateException
+            exc_location_id = self._handle_location_update(exception.get("location"), update_data.location) 
+            variables = {
+                "id": exception.get("id"),
+                "data": CalendarException.to_json(update_data, event_id, recurrence_id, exc_location_id)
             }
         else:
-            location_id = self._handle_location_update(
-                exception.get("location") if exception else None,
-                update_data.location
-            ) if update_data.location else None
+            file = GraphQLFile.kCreateException
+            variables = {
+                "data": CalendarException.to_json(update_data, event_id, recurrence_id)  
+            }
 
-            exc_data = CalendarException.to_json(update_data, event_id, recurrence_id, location_id)
+        item = self._execute_graphql_file(file, variables, [])
+        if not item:
+            raise DatabaseError(f"Failed to update {event_id}!")
 
-        file = GraphQLFile.kUpdateException if exception else GraphQLFile.kCreateException
-        variables = {
-            "id": exception.get("id"),
-            "data": exc_data
-        } if exception else {"data": exc_data}
+        exception_data = item.get("update_calendar_exceptions_item") \
+                            or item.get("create_calendar_exceptions_item")
 
-        result = self._execute_graphql_file(file, variables, [])
-        if not result:
-            raise DatabaseError(f"Failed to update/delete recurrence {recurrence_id} of event {event_id}")
-
-        if delete:
-            logger.info(f"Marked recurrence {recurrence_id} of event {event_id} as deleted.")
-            return []
-        
-        item = result.get("update_calendar_exceptions_item") or result.get("create_calendar_exceptions_item")
-        return [CalendarEvent.from_json(event, item)]
+        return [CalendarEvent.from_json(event, exception_data)]
 
     def update_event(self, 
         user_id: uuid.UUID, 
@@ -341,9 +327,6 @@ class CalendarService:
             case UpdateType.THIS: # only use for repeat frequencies, call Update.All for ONCE
                 logger.info(f"Updating single occurrence of calendar event {event_id}.")
                 return self._update_repeat_event(event_id, update_data, recurrence_id)
-            case UpdateType.DELETE_THIS:
-                logger.info(f"Deleting recurrence {recurrence_id} for calendar event {event_id}.")
-                return self._update_repeat_event(event_id, None, recurrence_id, delete=True)
             case UpdateType.ALL:
                 logger.info(f"Updating all occurrences of calendar event {event_id}.")
                 return self._update_event(user_id, event_id, update_data)

--- a/api/src/v1/calendar/services/calendar_service.py
+++ b/api/src/v1/calendar/services/calendar_service.py
@@ -1,20 +1,22 @@
 import uuid
-from typing import Optional
+from datetime import datetime, timedelta
 from enum import Enum
-from datetime import timedelta, datetime
 from pathlib import Path
+
 from dateutil.relativedelta import relativedelta
-from shared.src.core.exceptions import DatabaseError
+from typing import Optional
 
 from api.src.v1.calendar.models.calendar_model import (
-    Frequency, 
-    CalendarEntry, 
-    CalendarCreate, 
-    UpdateType,
+    AccessScope,
+    CalendarCreate,
+    CalendarEvent,
     CalendarException,
-    CalendarLocation
+    CalendarLocation,
+    Frequency,
+    UpdateType,
 )
 
+from shared.src.core.exceptions import DatabaseError
 from shared.src.core.logging import get_calendar_logger
 from shared.src.services.directus_service import DirectusService
 
@@ -94,14 +96,14 @@ class CalendarService:
         
         return self._safe_get(response, ["data"] + path)
 
-    def _get_entry_information(self, 
-        entry_id: uuid.UUID, 
+    def _get_event_information(self, 
+        event_id: uuid.UUID, 
         file: GraphQLFile,
         path: list
         ) -> Optional[dict]:
-        """Retrieves a specific entry from the database via a GraphQL file. The information contained may vary depending on the file."""
+        """Retrieves a specific event from the database via a GraphQL file. The information contained may vary depending on the file."""
         filters = {
-            "id": {"_eq": str(entry_id)}
+            "id": {"_eq": str(event_id)}
         }
    
         return self._execute_graphql_file(file, {"filter": filters}, path)
@@ -123,15 +125,15 @@ class CalendarService:
         parent_event: dict, 
         max_past: int = REPEAT_LIMIT,
         max_future: int = REPEAT_LIMIT, 
-        ) -> list[CalendarEntry]:
+        ) -> list[CalendarEvent]:
         """Generates all recurring event instances based on a parent event and its recurrence rule. 
         If there are exceptions, they will overwrite the corresponding event."""
         if parent_event is None:
             return []
         
-        parent_entry = CalendarEntry.from_json(parent_event)
+        parent_entry = CalendarEvent.from_json(parent_event)
         rule = parent_entry.rule
-        if not rule or rule.frequency == Frequency.ONCE:
+        if rule.frequency == Frequency.ONCE:
             return [parent_entry]
         
         delta = self._get_delta(rule.frequency, rule.interval or 1)
@@ -150,9 +152,9 @@ class CalendarService:
         result = []
 
         # helper
-        def generate_entry(offset: int, start: datetime, end: datetime) -> CalendarEntry:
+        def generate_entry(offset: int, start: datetime, end: datetime) -> CalendarEvent:
             if offset in exceptions_map:
-                return CalendarEntry.from_json(parent_event, exceptions_map[offset])
+                return CalendarEvent.from_json(parent_event, exceptions_map[offset])
             return parent_entry.copy_with_override(start_time=start, end_time=end, recurrence_id=offset)
 
         # past events
@@ -163,7 +165,7 @@ class CalendarService:
 
         # base event
         if 0 in exceptions_map:
-            entry = CalendarEntry.from_json(parent_event, exceptions_map[0])
+            entry = CalendarEvent.from_json(parent_event, exceptions_map[0])
         else:
             entry = parent_entry
         entry.recurrence_id = 0
@@ -178,7 +180,25 @@ class CalendarService:
         
         return result
     
-    def _delete_location_entry(self,
+    def create_event(self, 
+        user_id: uuid.UUID, 
+        calendar_data: CalendarCreate
+        ) -> list[CalendarEvent]:
+        """Creates a calendar event in the database. Returns a list of several recurring events based on the event rule."""  
+        create_event = CalendarCreate.to_json(calendar_data, user_id, None, None)   
+
+        item = self._execute_graphql_file(GraphQLFile.kCreate, {"data": create_event}, ["create_calendar_event_item"])
+        if not item:
+            raise DatabaseError("Failed to create calendar event!")
+
+        msg = "for all users!"
+        if user_id:
+            msg = f"for user {user_id}!"
+
+        logger.info(f"Created new calendar event {item["id"]} {msg}")
+        return self._generate_repeat_events(item, 0)
+    
+    def _delete_location_event(self,
         location_id: uuid.UUID
         ):
         if location_id:
@@ -186,55 +206,36 @@ class CalendarService:
             if not location_delete:
                 raise DatabaseError(f"Failed to delete location {location_id}!")
 
-    def _delete_related_entry(self,
-        entry_id: uuid.UUID, 
+    def _delete_related_event(self,
+        event_id: uuid.UUID, 
         information: dict                     
         ):
-        """Deletes the entry and some related entries to the calendar entry."""
+        """Deletes the event and some related entries to the calendar event."""
         rule_id = self._safe_get(information, ["rule", "id"])
         
-        rule_delete = self._execute_graphql_file(GraphQLFile.kDelete, { "eventId": str(entry_id), "ruleId": str(rule_id) }, [])
+        rule_delete = self._execute_graphql_file(GraphQLFile.kDelete, { "eventId": str(event_id), "ruleId": str(rule_id) }, [])
         if not rule_delete:
-            raise DatabaseError(f"Failed to delete {entry_id} and {rule_id}!")
+            raise DatabaseError(f"Failed to delete {event_id} and {rule_id}!")
         
         location_id = self._safe_get(information, ["location", "id"])
-        self._delete_location_entry(location_id)
+        self._delete_location_event(location_id)
 
-    def create_entry(self, 
-        user_id: uuid.UUID, 
-        calendar_data: CalendarCreate
-        ) -> list[CalendarEntry]:
-        """Creates a calendar entry in the database. Returns a list of several recurring events based on the event rule."""  
-        create_entry = CalendarCreate.to_json(calendar_data, user_id, None, None)   
-
-        item = self._execute_graphql_file(GraphQLFile.kCreate, {"data": create_entry}, ["create_calendar_event_item"])
-        if not item:
-            raise DatabaseError("Failed to create calendar entry!")
-
-        logger.info( f"Created new calendar entry {item["id"]} for user {user_id}")
-        return self._generate_repeat_events(item)
-
-    def delete_entry(self, 
-        entry_id: uuid.UUID
+    def delete_event(self, 
+        event_id: uuid.UUID
         ) -> bool:
-        """Deletes a calendar entry from the database."""    
-        information = self._get_entry_information(entry_id, GraphQLFile.kGetInformation, ["calendar_event", 0])      
+        """Deletes a calendar event from the database."""    
+        information = self._get_event_information(event_id, GraphQLFile.kGetInformation, ["calendar_event", 0])      
         if not information:
-            raise DatabaseError(f"No calendar event found with ID {entry_id}")
+            raise DatabaseError(f"No calendar event found with ID {event_id}")
         
-        self._delete_related_entry(entry_id, information)
-
         exceptions = information.get("exceptions", [])
         for exc in exceptions:
             exc_location_id = self._safe_get(exc, ["location", "id"])
-            self._delete_location_entry(exc_location_id)
+            self._delete_location_event(exc_location_id)
 
-            exc_id = exc.get("id")
-            exc_delete = self._execute_graphql_file(GraphQLFile.kDeleteException, {"exceptionId": exc_id}, [])
-            if not exc_delete:
-                raise DatabaseError(f"Failed to delete exception {exc_id}")
+        self._delete_related_event(event_id, information)
 
-        logger.info(f"Deleted calendar entry {entry_id}!")
+        logger.info(f"Deleted calendar event {event_id}!")
         return True
      
     def _handle_location_update(
@@ -247,7 +248,7 @@ class CalendarService:
 
         if not new_address:
             # address removed
-            self._delete_location_entry(old_id)
+            self._delete_location_event(old_id)
             return None
 
         if not old_id:
@@ -256,80 +257,96 @@ class CalendarService:
 
         return old_id  # address unchanged, updated
 
-    def _update_entry(self,
+    def _update_event(self,
         user_id: uuid.UUID, 
-        entry_id: uuid.UUID,     
+        event_id: uuid.UUID,     
         update_data: CalendarCreate,                   
-        ) -> list[CalendarEntry]:
+        ) -> list[CalendarEvent]:
         """Performs an update to the base event instance. Therefore all events are updated."""
-        event = self._get_entry_information(entry_id, GraphQLFile.kGetInformation, ["calendar_event", 0])        
+        event = self._get_event_information(event_id, GraphQLFile.kGetInformation, ["calendar_event", 0])        
         if not event:
-            raise DatabaseError(f"Failed to update {entry_id}! No information returned!")
+            raise DatabaseError(f"Failed to update {event_id}! No information returned!")
 
         rule_id = self._safe_get(event, ["rule", "id"])
         location = self._safe_get(event, ["location"])
         new_location_id = self._handle_location_update(location, update_data.location)
         json_data = CalendarCreate.to_json(update_data, user_id, rule_id, new_location_id)
 
-        item = self._execute_graphql_file(GraphQLFile.kUpdate, {"id": str(entry_id),"data": json_data}, ["update_calendar_event_item"])
+        item = self._execute_graphql_file(GraphQLFile.kUpdate, {"id": str(event_id),"data": json_data}, ["update_calendar_event_item"])
         if not item:
-            raise DatabaseError(f"Failed to update {entry_id}!")
+            raise DatabaseError(f"Failed to update {event_id}!")
         
         return self._generate_repeat_events(item)
 
-    def _update_repeat_entry(self,
-        entry_id: uuid.UUID,     
-        update_data: CalendarCreate,  
-        recurrence_id: int                 
-        ) -> list[CalendarEntry]:
-        """Performs an update to a generated event instance. Therefore a new exception is created or the existing one is updated."""
-        event = self._get_entry_information(entry_id, GraphQLFile.kGetEvent, ["calendar_event", 0]) 
+    def _update_repeat_event(
+        self,
+        event_id: uuid.UUID,
+        update_data: Optional[CalendarCreate],  # None if delete = True
+        recurrence_id: int,
+        delete: bool = False
+        ) -> list[CalendarEvent]:
+        """
+        Performs an update to a generated event instance.
+        If `delete` is True, creates or updates an exception marking the instance as deleted.
+        """
+        event = self._get_event_information(event_id, GraphQLFile.kGetEvent, ["calendar_event", 0]) 
         if not event:
-            raise DatabaseError(f"Failed to update {entry_id}! No information returned!")
+            raise DatabaseError(f"Failed to update {event_id}! No information returned!")
 
         exception = self._get_exception_by_id(event.get("exceptions"), recurrence_id)
 
-        if exception:
-            file = GraphQLFile.kUpdateException
-            exc_location_id = self._handle_location_update(exception.get("location"), update_data.location) 
-            variables = {
-                "id": exception.get("id"),
-                "data": CalendarException.to_json(update_data, entry_id, recurrence_id, exc_location_id)
+        if delete:
+            exc_data = {
+                "recurrence_id": recurrence_id,
+                "event": { "id": str(event_id) },
+                "deleted": True 
             }
         else:
-            file = GraphQLFile.kCreateException
-            variables = {
-                "data": CalendarException.to_json(update_data, entry_id, recurrence_id)  
-            }
+            location_id = self._handle_location_update(
+                exception.get("location") if exception else None,
+                update_data.location
+            ) if update_data.location else None
 
-        item = self._execute_graphql_file(file, variables, [])
-        if not item:
-            raise DatabaseError(f"Failed to update {entry_id}!")
+            exc_data = CalendarException.to_json(update_data, event_id, recurrence_id, location_id)
 
-        exception_data = item.get("update_calendar_exceptions_item") \
-                            or item.get("create_calendar_exceptions_item")
+        file = GraphQLFile.kUpdateException if exception else GraphQLFile.kCreateException
+        variables = {
+            "id": exception.get("id"),
+            "data": exc_data
+        } if exception else {"data": exc_data}
 
-        return [CalendarEntry.from_json(event, exception_data)]
+        result = self._execute_graphql_file(file, variables, [])
+        if not result:
+            raise DatabaseError(f"Failed to update/delete recurrence {recurrence_id} of event {event_id}")
 
-    def update_entry(self, 
+        if delete:
+            logger.info(f"Marked recurrence {recurrence_id} of event {event_id} as deleted.")
+            return []
+        
+        item = result.get("update_calendar_exceptions_item") or result.get("create_calendar_exceptions_item")
+        return [CalendarEvent.from_json(event, item)]
+
+    def update_event(self, 
         user_id: uuid.UUID, 
-        entry_id: uuid.UUID, 
+        event_id: uuid.UUID, 
         recurrence_id: int,
         update_data: CalendarCreate, 
         update_type: UpdateType
-        ) -> list[CalendarEntry]:
+        ) -> list[CalendarEvent]:
         """Updates calendar entries in the database."""
         if recurrence_id is None:
             update_type = UpdateType.ALL
 
         match update_type:
             case UpdateType.THIS: # only use for repeat frequencies, call Update.All for ONCE
-                # generate an overwrite and attach
-                logger.info(f"Updating single occurrence of calendar entry {entry_id} for user {user_id}")
-                return self._update_repeat_entry(entry_id, update_data, recurrence_id)
+                logger.info(f"Updating single occurrence of calendar event {event_id}.")
+                return self._update_repeat_event(event_id, update_data, recurrence_id)
+            case UpdateType.DELETE_THIS:
+                logger.info(f"Deleting recurrence {recurrence_id} for calendar event {event_id}.")
+                return self._update_repeat_event(event_id, None, recurrence_id, delete=True)
             case UpdateType.ALL:
-                logger.info(f"Updating all occurrences of calendar entry {entry_id} for user {user_id}")
-                return self._update_entry(user_id, entry_id, update_data)
+                logger.info(f"Updating all occurrences of calendar event {event_id}.")
+                return self._update_event(user_id, event_id, update_data)
             case UpdateType.FUTURE: # split 
                 logger.info("Not implemented yet!")
                 return []
@@ -340,21 +357,37 @@ class CalendarService:
     def get_all(
         self,
         user_id: uuid.UUID,
+        access_scope: AccessScope,
         event_type: Optional[str] = None,
         frequency: Optional[str] = None,
         all_day: Optional[bool] = None
-    ) -> list[CalendarEntry]:
-        """Returns a list of all calendar entries for a user. Several filters are optionally available."""
-        filters = {
-            "user_id": {"_eq": str(user_id)}
+    ) -> list[CalendarEvent]:
+        """Returns a list of all calendar events for a user. Several filters are optionally available. Includes global events with access_scope <= given level."""
+        
+        user_filter = {
+            "_or": [
+                {"user_id": {"_eq": str(user_id)}},
+                {"user_id": {"_null": True}}
+            ]
         }
 
+        access_scope_filter = {
+            "access_scope": {"_lte": access_scope}
+        }
+
+        filters = {
+            "_and": [
+                user_filter,
+                access_scope_filter
+            ]
+        }
+        
         if event_type:
-            filters["event_type"] = {"_eq": event_type}
+            filters["_and"].append({"event_type": {"_eq": event_type}})
         if all_day is not None:
-            filters["all_day"] = {"_eq": all_day}
+            filters["_and"].append({"all_day": {"_eq": all_day}})
         if frequency:
-            filters["rule"] = {"frequency": {"_eq": frequency}}
+            filters["_and"].append({"rule": {"frequency": {"_eq": frequency}}})
 
         events = self._execute_graphql_file(GraphQLFile.kGetEvent, {"filter": filters}, ["calendar_event"])
         if not events:


### PR DESCRIPTION
- allow events to be created for all users with the AccessScope enum and the new endpoints
- logic which event is visible to which user can be easily adjusted using the enum if several access levels are required in future at some point
- the get function will return all public events too if requested based on the access scope parameter (if there's need for a separate request I can add it)

- furthermore all mixed uses of "entry" and "event" have now been renamed to "event"
- simplified the delete function a little based on relationship deletion in directus