### PR TITLE
feat: add iCal subscription feed

### DIFF
--- a/api/src/v1/calendar/graphql/delete_event.graphql
+++ b/api/src/v1/calendar/graphql/delete_event.graphql
@@ -1,8 +1,4 @@
-mutation DeleteCalendarEvent(
-  $eventId: ID!, 
-  $ruleId: ID! 
-) {
-  
+mutation DeleteCalendarEvent($eventId: ID!, $ruleId: ID!) {
   delete_calendar_event_item(id: $eventId) {
     id
   }

--- a/api/src/v1/calendar/models/calendar_model.py
+++ b/api/src/v1/calendar/models/calendar_model.py
@@ -20,7 +20,7 @@ class Frequency(str, Enum):
     MONTHLY = "MONTHLY"
     YEARLY = "YEARLY"
 
-class UpdateType(int, Enum):
+class UpdateType(int, Enum): # enum case 1 will be added and used at some point
     THIS = 0
     ALL = 2
     FUTURE = 3

--- a/api/src/v1/calendar/routers/calendar_router.py
+++ b/api/src/v1/calendar/routers/calendar_router.py
@@ -1,8 +1,7 @@
 import uuid
-
 from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 
 from api.src.v1.calendar.models.calendar_model import (
     AccessScope,
@@ -70,3 +69,9 @@ async def get_events(
 ):
     events = CalendarService().get_all(user.id, access_scope, event_type, frequency, all_day)
     return CalendarEntries.from_list(events)
+
+@router.get("/calendar/ical/{user_id}.ics", description="Public iCal feed for a user's events.")
+async def get_user_ical_feed(
+    user_id: uuid.UUID
+):
+    return Response(content=CalendarService().generate_ical(user_id), media_type="text/calendar")

--- a/api/src/v1/calendar/services/calendar_service.py
+++ b/api/src/v1/calendar/services/calendar_service.py
@@ -395,16 +395,12 @@ class CalendarService:
         ical_event.add("uid", uid)
         ical_event.add("dtstamp", event.created_at)
 
-        if event.all_day and event.start_time:
-            # event is all day
+        if event.all_day:
             ical_event.add("dtstart", event.start_time.date())
-            if event.end_time:
-                ical_event.add("dtend", event.end_time.date())
+            ical_event.add("dtend", event.end_time.date())
         else:
-            if event.start_time:
-                ical_event.add("dtstart", event.start_time)
-            if event.end_time:
-                ical_event.add("dtend", event.end_time)
+            ical_event.add("dtstart", event.start_time)
+            ical_event.add("dtend", event.end_time)
 
         if event.description:
             ical_event.add("description", event.description)

--- a/api/src/v1/calendar/services/calendar_service.py
+++ b/api/src/v1/calendar/services/calendar_service.py
@@ -2,9 +2,9 @@ import uuid
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
-
 from dateutil.relativedelta import relativedelta
 from typing import Optional
+from icalendar import Calendar, Event
 
 from api.src.v1.calendar.models.calendar_model import (
     AccessScope,
@@ -337,8 +337,7 @@ class CalendarService:
                 logger.warning(f"Unknown update type: {update_type}")
                 return []
     
-    def get_all(
-        self,
+    def get_all(self,
         user_id: uuid.UUID,
         access_scope: AccessScope,
         event_type: Optional[str] = None,
@@ -381,3 +380,54 @@ class CalendarService:
             instances.extend(self._generate_repeat_events(event))
 
         return instances
+
+    def _calendar_event_to_ical(self,
+        event: CalendarEvent
+    ) -> Event:
+
+        ical_event = Event()
+        ical_event.add("summary", event.title)
+
+        uid = f"{event.id}"
+        if event.recurrence_id is not None:
+            uid += f"-recurrence-{event.recurrence_id}"
+
+        ical_event.add("uid", uid)
+        ical_event.add("dtstamp", event.created_at)
+
+        if event.all_day and event.start_time:
+            # event is all day
+            ical_event.add("dtstart", event.start_time.date())
+            if event.end_time:
+                ical_event.add("dtend", event.end_time.date())
+        else:
+            if event.start_time:
+                ical_event.add("dtstart", event.start_time)
+            if event.end_time:
+                ical_event.add("dtend", event.end_time)
+
+        if event.description:
+            ical_event.add("description", event.description)
+
+        if event.location:
+            ical_event.add("location", event.location.address)
+
+        return ical_event
+
+    def generate_ical(self, 
+        user_id: uuid.UUID
+        ) -> bytes:
+        """Generates an iCal file with all events for a specific user."""
+        if not user_id:
+            raise DatabaseError(f"Got ical request with user_id = None!")
+        
+        cal = Calendar()
+        cal.add("prodid", "-//lmu-devs//LMU Students//EN")
+        cal.add("version", "2.0")
+        cal.add("method", "PUBLISH")
+
+        for event in self.get_all(user_id, AccessScope.USER):
+            ical_event = self._calendar_event_to_ical(event)
+            cal.add_component(ical_event)
+
+        return cal.to_ical()

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ isort==6.0.1
 litellm==1.66.3
 geopy==2.4.1
 markdownify==1.1.0
+icalendar


### PR DESCRIPTION
- add endpoint for event subscription feed
- atm it uses the userID as iCal file name. If the ID should not be public in this case I can generate an independant one, but it'll get more complicated
- it uses [icalendar](https://github.com/collective/icalendar) lib
- the iCal format appears to be correct; it can be imported correctly into Google Calendar
- we'll see if it really works when it runs on staging; the link won't work with the local server for Google Calendar it seems