### PR TITLE
[FEAT] Add Lecture Details API Endpoint

### DIFF
--- a/api/src/v1/classes/models/lecture.py
+++ b/api/src/v1/classes/models/lecture.py
@@ -1,7 +1,7 @@
 import re
 from pydantic import BaseModel, Field, RootModel
 from typing import Any, List, Tuple, Optional
-from datetime import time, date as Date
+from datetime import datetime, time, date as Date
 
 from shared.src.enums.weekday_enum import WeekdayEnum
 from shared.src.enums.classes_enum import LectureStartTypeEnum
@@ -130,6 +130,13 @@ class AssociatedTutorial(BaseModel):
 class EnrollmentDeadline(BaseModel):
     program_associated_deadline: Optional[str] = Field(None)
     other_deadlines: Optional[str] = Field(None)
+
+
+class LectureDetails(BaseModel):
+    sessions: Optional[list[ClassSession]]
+    persons: Optional[list[Person]]
+    addtional_information: Optional[str]
+    last_updated: Optional[datetime]
 
 
 class LectureBasic(BaseModel):

--- a/api/src/v1/classes/routers/lecture_router.py
+++ b/api/src/v1/classes/routers/lecture_router.py
@@ -3,7 +3,7 @@ import datetime
 from fastapi import APIRouter, Depends
 
 from ..services.lecture_service import LectureService
-from ..models.lecture import LecturesBasic
+from ..models.lecture import LecturesBasic, LectureDetails
 from shared.src.core.database import get_async_db
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,4 +31,19 @@ async def get_courses_from_faculty(
         year,
         term_id
     )
+    return result
+
+
+@router.get(
+    "/course-details",
+    response_model=LectureDetails,
+    description="Get all courses from a specified faculty",
+)
+async def get_course_details(
+    publish_id: int,
+    session: AsyncSession = Depends(get_async_db),
+) -> LectureDetails:
+    """Endpoint to get course from a specific faculty."""
+    lecture_service = LectureService()
+    result = await lecture_service.get_lecture_details_db(session, publish_id)
     return result

--- a/api/src/v1/classes/services/lecture_service.py
+++ b/api/src/v1/classes/services/lecture_service.py
@@ -1,18 +1,16 @@
 from pathlib import Path
-from typing import List
-
-from api.src.v1.core.flatten_response_util import flatten_response
+from typing import Optional
 from shared.src.core.settings import get_settings
-from shared.src.tables.lectures import LectureTable, TreePathTable, ClassBaseInfoTable
+from shared.src.tables.lectures import PersonTable, ClassSessionTable, LectureTable, TreePathTable, ClassBaseInfoTable, AdditionInformationTable, lecture_persons_table
 from shared.src.services.directus_service import DirectusService
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import (
-    text,
-    select,
+    select
 )
 
+from lxml import html
 
-from ..models.lecture import LecturesBasic, LectureBasic
+from ..models.lecture import LectureDetails, LecturesBasic, LectureBasic, ClassSession, Person
 from shared.src.enums.faculty_enums import (
     LanguageEnum,
 )
@@ -41,6 +39,100 @@ class LectureService:
         )
         return LecturesBasic.from_directus_dict(response["data"]["lecture"])
 
+    async def get_lecture_details_db(self, session: AsyncSession, publish_id: int) -> LectureDetails:
+        stmt = (
+            select(LectureTable)
+            .where(LectureTable.publish_id == publish_id)
+        ).distinct()
+
+        result = await session.execute(stmt)
+        lecture = result.scalar_one_or_none()
+
+        if not lecture:
+            raise ValueError(f"Lecture with publish_id {publish_id} not found")
+
+        columns = [
+            col for col in AdditionInformationTable.__table__.c
+            if col.name != "id"
+        ]
+
+        base_stmt = (
+            select(*columns)
+            .where(AdditionInformationTable.lecture_publish_id == publish_id)
+        ).distinct()
+        base_result = await session.execute(base_stmt)
+        base_row = base_result.mappings().one_or_none()
+
+        sessions_stmt = (
+            select(ClassSessionTable)
+            .where(ClassSessionTable.lecture_publish_id == publish_id)
+        ).distinct()
+
+        sessions_result = await session.execute(sessions_stmt)
+        sessions = sessions_result.scalars().all()
+
+        persons_stmt = (
+            select(
+                PersonTable.first_name,
+                PersonTable.surname,
+                PersonTable.title
+            )
+            .join(lecture_persons_table, PersonTable.id == lecture_persons_table.c.person_id)
+            .where(lecture_persons_table.c.lecture_publish_id == publish_id)
+            .distinct()
+        )
+
+        result = await session.execute(persons_stmt)
+        persons = result.mappings().all()
+
+        return LectureDetails(
+            last_updated=lecture.last_updated,
+            persons=[Person.model_validate(person) for person in persons],
+            sessions=[ClassSession.model_validate(session.__dict__) for session in sessions],
+            addtional_information=self.convert_additional_info_to_markdown(base_row)
+        )
+
+    def html_to_text(self, html_str: str) -> str:
+        if not html_str:
+            return ""
+        try:
+            tree = html.fromstring(html_str)
+            return tree.text_content().strip()
+        except Exception:
+            return html_str.strip()
+
+    def convert_additional_info_to_markdown(self, add_info: Optional[AdditionInformationTable]) -> str:
+        if not add_info:
+            return ""
+
+        field_translations = {
+            "remark": "Bemerkung",
+            "literature": "Literatur",
+            "date": "Datum",
+            "registration": "Anmeldung",
+            "format": "Format",
+            "content": "Inhalt",
+            "learning_content": "Lerninhalte",
+            "target_group": "Zielgruppe",
+            "location": "Ort",
+            "comment": "Kommentar",
+            "assessment": "Leistungsnachweis",
+            "time": "Zeit",
+            "topic": "Thema",
+            "short_comment": "Kurzkommentar",
+            "prerequisites": "Voraussetzungen",
+            "number": "Nummer",
+            "type": "Typ"
+        }
+
+        markdown_parts = []
+        for field, translation in field_translations.items():
+            value = getattr(add_info, field)
+            text = self.html_to_text(value)
+            if text:
+                markdown_parts.append(f"### {translation.title()}\n\n{text}")
+
+        return "\n\n".join(markdown_parts)
 
     async def get_lectures_from_faculty_db(self, session: AsyncSession, faculty_id: int, year: int, semester_id: int):
         """Get all lectures from a specific faculty, semester and year."""

--- a/api/src/v1/classes/services/lecture_service.py
+++ b/api/src/v1/classes/services/lecture_service.py
@@ -3,6 +3,7 @@ from typing import Optional
 from shared.src.core.settings import get_settings
 from shared.src.tables.lectures import PersonTable, ClassSessionTable, LectureTable, TreePathTable, ClassBaseInfoTable, AdditionInformationTable, lecture_persons_table
 from shared.src.services.directus_service import DirectusService
+from data_fetcher.src.core.html_utils import html_to_markdown
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import (
     select
@@ -92,15 +93,6 @@ class LectureService:
             addtional_information=self.convert_additional_info_to_markdown(base_row)
         )
 
-    def html_to_text(self, html_str: str) -> str:
-        if not html_str:
-            return ""
-        try:
-            tree = html.fromstring(html_str)
-            return tree.text_content().strip()
-        except Exception:
-            return html_str.strip()
-
     def convert_additional_info_to_markdown(self, add_info: Optional[AdditionInformationTable]) -> str:
         if not add_info:
             return ""
@@ -128,7 +120,7 @@ class LectureService:
         markdown_parts = []
         for field, translation in field_translations.items():
             value = getattr(add_info, field)
-            text = self.html_to_text(value)
+            text = html_to_markdown(value)
             if text:
                 markdown_parts.append(f"### {translation.title()}\n\n{text}")
 

--- a/data_fetcher/src/classes/models/lecture.py
+++ b/data_fetcher/src/classes/models/lecture.py
@@ -472,7 +472,7 @@ class Lecture(BaseModel):
 
     def _one_to_many_to_table(self, attr: str, related: dict, lecture: LectureTable):
         """Convert a one-to-many relationship to a list of table objects."""
-        values = getattr(self, attr, [])
+        values = getattr(self, attr, []) or []
         for item in values:
             table_obj = item.to_table()
             table_obj.lecture = lecture
@@ -480,7 +480,7 @@ class Lecture(BaseModel):
 
     def _many_to_many_to_table(self, attr: str, related: dict):
         """Convert a many-to-many relationship to a list of table objects."""
-        values = getattr(self, attr, [])
+        values = getattr(self, attr, []) or []
         for item in values:
             related[attr].append(item.to_table())
 

--- a/shared/src/tables/lectures/lecture_tables.py
+++ b/shared/src/tables/lectures/lecture_tables.py
@@ -1,5 +1,5 @@
 from sqlalchemy import (
-    ARRAY,
+    func, DateTime, ARRAY,
     Column,
     Date,
     Enum,
@@ -20,14 +20,14 @@ from shared.src.enums.classes_enum import LectureStartTypeEnum
 
 lecture_persons_table = Table(
     'lecture_persons', Base.metadata,
-    Column('lecture_publish_id', Integer, ForeignKey('lectures.publish_id')),
-    Column('person_id', Integer, ForeignKey('persons.id'))
+    Column('lecture_publish_id', Integer, ForeignKey('lectures.publish_id', ondelete='CASCADE')),
+    Column('person_id', Integer, ForeignKey('persons.id', ondelete='CASCADE'))
 )
 
 lecture_institutions_table = Table(
     'lecture_institutions', Base.metadata,
-    Column('lecture_publish_id', Integer, ForeignKey('lectures.publish_id')),
-    Column('institution_id', Integer, ForeignKey('institutions.id'))
+    Column('lecture_publish_id', Integer, ForeignKey('lectures.publish_id', ondelete='CASCADE')),
+    Column('institution_id', Integer, ForeignKey('institutions.id', ondelete='CASCADE'))
 )
 
 class TreePathTable(Base):
@@ -74,17 +74,17 @@ class ClassBaseInfoTable(Base):
     __tablename__ = 'class_base_info'
 
     id = Column(Integer, primary_key=True)
-    class_type = Column(String(255), nullable=True)
-    class_id = Column(String(255), nullable=True)
-    class_cycle = Column(String(255), nullable=True)
-    semester = Column(String(255), nullable=True)
+    class_type = Column(String(500), nullable=True)
+    class_id = Column(String(500), nullable=True)
+    class_cycle = Column(String(500), nullable=True)
+    semester = Column(String(500), nullable=True)
     sws = Column(Float, nullable=True)
     max_participants = Column(Integer, nullable=True)
-    in_person_type = Column(String(255), nullable=True)
-    language = Column(String(255), nullable=True)
-    for_exchange_students = Column(String(255), nullable=True)
+    in_person_type = Column(String(500), nullable=True)
+    language = Column(String(500), nullable=True)
+    for_exchange_students = Column(Text, nullable=True)
     links = Column(Text, nullable=True)
-    sigel = Column(String(255), nullable=True)
+    sigel = Column(Text, nullable=True)
     lecture_publish_id = Column(Integer, ForeignKey('lectures.publish_id'))
 
     lecture = relationship("LectureTable", back_populates="base_info", uselist=False)
@@ -101,8 +101,8 @@ class ClassSessionTable(Base):
     rythm = Column(String(255), nullable=True)
     duration_start = Column(Date, nullable=True)
     duration_end = Column(Date, nullable=True)
-    room = Column(String(255), nullable=True)
-    lecturer = Column(String(255), nullable=True)
+    room = Column(String(500), nullable=True)
+    lecturer = Column(String(500), nullable=True)
     remark = Column(Text, nullable=True)
     cancelled_dates = Column(Text, nullable=True)
     lecture_publish_id = Column(Integer, ForeignKey('lectures.publish_id'))
@@ -115,7 +115,7 @@ class ClassMaterialTable(Base):
     id = Column(Integer, primary_key=True)
     valid_from = Column(Date, nullable=True)
     valid_to = Column(Date, nullable=True)
-    file_name = Column(String(255), nullable=True)
+    file_name = Column(String(500), nullable=True)
     description = Column(Text, nullable=True)
     lecture_publish_id = Column(Integer, ForeignKey('lectures.publish_id'))
 
@@ -217,6 +217,7 @@ class LectureTable(Base):
 
     publish_id = Column(Integer, primary_key=True)
     title = Column(String(500), nullable=False)
+    last_updated = Column(DateTime, default=func.now(), onupdate=func.now())
 
     base_info = relationship("ClassBaseInfoTable", back_populates="lecture", uselist=False, cascade="all, delete-orphan")
     additional_information = relationship("AdditionInformationTable", back_populates="lecture", uselist=False, cascade="all, delete-orphan")


### PR DESCRIPTION
# [FEAT] Add Lecture Details API Endpoint

## 📘 Business Logic

This PR introduces a backend endpoint to fetch detailed information about a lecture (`publish_id` based). It enables the frontend to display:

- All class sessions
- Associated persons (lecturers, assistants, etc.)
- Additional structured metadata (format, assessment, registration, etc.) rendered in Markdown
- Last updated timestamp

The endpoint simplifies and centralizes logic that was previously distributed across multiple frontend GraphQL calls.

---

## 📚 Context

This is part of the broader effort to migrate away from GraphQL and replace it with clear, REST-based API endpoints.

The new endpoint supports the lecture details page in the frontend app (`lmu_app_client`) and replaces the previously fragmented data model resolution.

---

## 🛠 Technical Details

### 🔗 New Endpoint

```http
GET /course-details?publish_id=<int>
