### PR TITLE
feat: make recurring events relative to today

### DIFF
--- a/api/src/v1/calendar/services/calendar_service.py
+++ b/api/src/v1/calendar/services/calendar_service.py
@@ -123,7 +123,9 @@ class CalendarService:
          
     def _calc_intervals_since_start(self, 
         start: datetime, 
-        now: datetime, delta) -> int:
+        now: datetime, 
+        delta
+        ) -> int:
         """Calculates the number of intervals happend between now and the start time."""
         if isinstance(delta, timedelta):
             return (now - start) // delta
@@ -159,19 +161,7 @@ class CalendarService:
         
         raw_exceptions = self._safe_get(parent_event, ["exceptions"]) or []
         exceptions_map = { exc.get("recurrence_id"): exc for exc in raw_exceptions if "recurrence_id" in exc }
-
-        event_duration = template.end_time - template.start_time
-        intervals_since_start = self._calc_intervals_since_start(template.start_time, datetime.now(), delta)
-        
-        # Prevent the creation of events that shouldn't exist if we create an event in the future
-        if intervals_since_start < 0:
-            intervals_since_start = 0
-            current_start = template.start_time
-        else:
-            current_start = template.start_time + intervals_since_start * delta
-
-        current_end = current_start + event_duration
-
+ 
         # helper
         def generate_entry(offset: int, start: datetime, end: datetime) -> CalendarEvent:
             exc = exceptions_map.get(offset)
@@ -179,29 +169,34 @@ class CalendarService:
                 return CalendarEvent.from_json(parent_event, exc)
             return template.copy_with_override(start_time=start, end_time=end, recurrence_id=offset)
 
+        # calculate the offset from the template.start_time until today. This is our relative "today"
+        # negativ if the event starts in the future
+        base_id = self._calc_intervals_since_start(template.start_time, datetime.now(), delta)
+        event_duration = template.end_time - template.start_time
+
+        # the start_time of the event is in the past, we are in the future
+        if base_id >= 0:
+            start_id = max(0, base_id - max_past)
+            end_id = base_id + max_future
+        # the event is starting in the future
+        else:
+            start_id = 0
+            end_id = max_future
+
         result = []
-
-        # past
-        # only create past events if the event is not in the future
-        for i in range(min(max_past, intervals_since_start), 0, -1):
-            past_start = current_start - i * delta 
-            past_end = past_start + event_duration
-            if past_start >= template.start_time:
-                recurrence_id = intervals_since_start - i
-                result.append(generate_entry(recurrence_id, past_start, past_end))
-      
-        # "today"
-        recurrence_id = intervals_since_start
-        result.append(generate_entry(recurrence_id, current_start, current_end))
-
-        # future
-        for i in range(1, max_future + 1):
-            future_start = current_start + i * delta
-            future_end = future_start + event_duration
-            if rule.until_time and future_start > rule.until_time: # TODO: invent new exception system :(
+    
+        for i in range(start_id, end_id + 1):
+            current_start = template.start_time + i * delta
+        
+            # end loop if end date is reached
+            if rule.until_time and current_start > rule.until_time:
                 break
-            recurrence_id = intervals_since_start + i
-            result.append(generate_entry(recurrence_id, future_start, future_end))
+
+            current_end = current_start + event_duration
+        
+            # i is the offset from template.start_time to the generated instance
+            # this allows the exception system to function
+            result.append(generate_entry(i, current_start, current_end))
 
         return result
     

--- a/api/src/v1/calendar/services/calendar_service.py
+++ b/api/src/v1/calendar/services/calendar_service.py
@@ -162,13 +162,6 @@ class CalendarService:
         raw_exceptions = self._safe_get(parent_event, ["exceptions"]) or []
         exceptions_map = { exc.get("recurrence_id"): exc for exc in raw_exceptions if "recurrence_id" in exc }
  
-        # helper
-        def generate_entry(offset: int, start: datetime, end: datetime) -> CalendarEvent:
-            exc = exceptions_map.get(offset)
-            if exc:
-                return CalendarEvent.from_json(parent_event, exc)
-            return template.copy_with_override(start_time=start, end_time=end, recurrence_id=offset)
-
         # calculate the offset from the template.start_time until today. This is our relative "today"
         # negativ if the event starts in the future
         base_id = self._calc_intervals_since_start(template.start_time, datetime.now(), delta)
@@ -195,8 +188,14 @@ class CalendarService:
             current_end = current_start + event_duration
         
             # i is the offset from template.start_time to the generated instance
-            # this allows the exception system to function
-            result.append(generate_entry(i, current_start, current_end))
+            # this allows the exception system to function      
+            exc = exceptions_map.get(i)
+            if exc:
+                event = CalendarEvent.from_json(parent_event, exc)
+            else:
+                event = template.copy_with_override(start_time=current_start, end_time=current_end, recurrence_id=i)
+            
+            result.append(event)
 
         return result
     

--- a/api/src/v1/calendar/services/calendar_service.py
+++ b/api/src/v1/calendar/services/calendar_service.py
@@ -121,7 +121,24 @@ class CalendarService:
                 return entry
         return None
          
-    def _generate_repeat_events(self, 
+    def _calc_intervals_since_start(self, 
+        start: datetime, 
+        now: datetime, delta) -> int:
+        """Calculates the number of intervals happend between now and the start time."""
+        if isinstance(delta, timedelta):
+            return (now - start) // delta
+        elif isinstance(delta, relativedelta):
+            # months or years
+            months_diff = (now.year - start.year) * 12 + (now.month - start.month)
+            if delta.years:
+                interval_months = delta.years * 12
+            else:
+                interval_months = delta.months
+            return months_diff // interval_months
+        else:
+            return 0
+
+    def _generate_recurring_events(self, 
         parent_event: dict, 
         max_past: int = REPEAT_LIMIT,
         max_future: int = REPEAT_LIMIT, 
@@ -143,18 +160,17 @@ class CalendarService:
         raw_exceptions = self._safe_get(parent_event, ["exceptions"]) or []
         exceptions_map = { exc.get("recurrence_id"): exc for exc in raw_exceptions if "recurrence_id" in exc }
 
-        now = datetime.now()
         event_duration = template.end_time - template.start_time
-        intervals_since_start = (now - template.start_time) // delta
+        intervals_since_start = self._calc_intervals_since_start(template.start_time, datetime.now(), delta)
         
         # Prevent the creation of events that shouldn't exist if we create an event in the future
         if intervals_since_start < 0:
             intervals_since_start = 0
             current_start = template.start_time
-            current_end = current_start + event_duration
         else:
             current_start = template.start_time + intervals_since_start * delta
-            current_end = current_start + event_duration
+
+        current_end = current_start + event_duration
 
         # helper
         def generate_entry(offset: int, start: datetime, end: datetime) -> CalendarEvent:
@@ -182,7 +198,7 @@ class CalendarService:
         for i in range(1, max_future + 1):
             future_start = current_start + i * delta
             future_end = future_start + event_duration
-            if rule.until_time and future_start > rule.until_time: # TODO: fix until_time, invent new exception system :(
+            if rule.until_time and future_start > rule.until_time: # TODO: invent new exception system :(
                 break
             recurrence_id = intervals_since_start + i
             result.append(generate_entry(recurrence_id, future_start, future_end))
@@ -205,7 +221,7 @@ class CalendarService:
             msg = f"for user {user_id}!"
 
         logger.info(f"Created new calendar event {item["id"]} {msg}")
-        return self._generate_repeat_events(item, 0)
+        return self._generate_recurring_events(item, 0)
     
     def _delete_location_event(self,
         location_id: uuid.UUID
@@ -285,7 +301,7 @@ class CalendarService:
         if not item:
             raise DatabaseError(f"Failed to update {event_id}!")
         
-        return self._generate_repeat_events(item)
+        return self._generate_recurring_events(item)
 
     def _update_repeat_event(self,
         event_id: uuid.UUID,     
@@ -386,7 +402,7 @@ class CalendarService:
 
         instances = []
         for event in events:
-            instances.extend(self._generate_repeat_events(event))
+            instances.extend(self._generate_recurring_events(event))
 
         return instances
 

--- a/api/src/v1/calendar/services/calendar_service.py
+++ b/api/src/v1/calendar/services/calendar_service.py
@@ -131,53 +131,63 @@ class CalendarService:
         if parent_event is None:
             return []
         
-        parent_entry = CalendarEvent.from_json(parent_event)
-        rule = parent_entry.rule
+        template = CalendarEvent.from_json(parent_event)
+        rule = template.rule
         if rule.frequency == Frequency.ONCE:
-            return [parent_entry]
+            return [template]
         
         delta = self._get_delta(rule.frequency, rule.interval or 1)
         if delta is None:
-            return [parent_entry]
-    
+            return [template]
+        
         raw_exceptions = self._safe_get(parent_event, ["exceptions"]) or []
-        exceptions_map = {
-            exc.get("recurrence_id"): exc
-            for exc in raw_exceptions
-            if "recurrence_id" in exc
-        }
+        exceptions_map = { exc.get("recurrence_id"): exc for exc in raw_exceptions if "recurrence_id" in exc }
 
-        base_start = parent_entry.start_time
-        base_end = parent_entry.end_time
-        result = []
+        now = datetime.now()
+        event_duration = template.end_time - template.start_time
+        intervals_since_start = (now - template.start_time) // delta
+        
+        # Prevent the creation of events that shouldn't exist if we create an event in the future
+        if intervals_since_start < 0:
+            intervals_since_start = 0
+            current_start = template.start_time
+            current_end = current_start + event_duration
+        else:
+            current_start = template.start_time + intervals_since_start * delta
+            current_end = current_start + event_duration
 
         # helper
         def generate_entry(offset: int, start: datetime, end: datetime) -> CalendarEvent:
-            if offset in exceptions_map:
-                return CalendarEvent.from_json(parent_event, exceptions_map[offset])
-            return parent_entry.copy_with_override(start_time=start, end_time=end, recurrence_id=offset)
+            exc = exceptions_map.get(offset)
+            if exc:
+                return CalendarEvent.from_json(parent_event, exc)
+            return template.copy_with_override(start_time=start, end_time=end, recurrence_id=offset)
 
-        # past events
-        for i in range(max_past, 0, -1):
-            start, end = base_start - i * delta, base_end - i * delta
-            if not rule.until_time or end >= rule.until_time:
-               result.append(generate_entry(-i, start, end))
+        result = []
 
-        # base event
-        if 0 in exceptions_map:
-            entry = CalendarEvent.from_json(parent_event, exceptions_map[0])
-        else:
-            entry = parent_entry
-        entry.recurrence_id = 0
-        result.append(entry)
+        # past
+        # only create past events if the event is not in the future
+        if intervals_since_start > 0:
+            for i in range(min(max_past, intervals_since_start), 0, -1):
+                past_start = current_start - i * delta
+                past_end = past_start + event_duration
+                if past_start >= template.start_time:
+                    recurrence_id = intervals_since_start - i
+                    result.append(generate_entry(recurrence_id, past_start, past_end))
+      
+        # "today"
+        recurrence_id = intervals_since_start
+        result.append(generate_entry(recurrence_id, current_start, current_end))
 
-        # future events
+        # future
         for i in range(1, max_future + 1):
-            start, end = base_start + i * delta, base_end + i * delta
-            if rule.until_time and start > rule.until_time:
+            future_start = current_start + i * delta
+            future_end = future_start + event_duration
+            if rule.until_time and future_start > rule.until_time: # TODO: fix until_time, invent new exception system :(
                 break
-            result.append(generate_entry(i, start, end))
-        
+            recurrence_id = intervals_since_start + i
+            result.append(generate_entry(recurrence_id, future_start, future_end))
+
         return result
     
     def create_event(self, 

--- a/api/src/v1/calendar/services/calendar_service.py
+++ b/api/src/v1/calendar/services/calendar_service.py
@@ -167,13 +167,12 @@ class CalendarService:
 
         # past
         # only create past events if the event is not in the future
-        if intervals_since_start > 0:
-            for i in range(min(max_past, intervals_since_start), 0, -1):
-                past_start = current_start - i * delta
-                past_end = past_start + event_duration
-                if past_start >= template.start_time:
-                    recurrence_id = intervals_since_start - i
-                    result.append(generate_entry(recurrence_id, past_start, past_end))
+        for i in range(min(max_past, intervals_since_start), 0, -1):
+            past_start = current_start - i * delta 
+            past_end = past_start + event_duration
+            if past_start >= template.start_time:
+                recurrence_id = intervals_since_start - i
+                result.append(generate_entry(recurrence_id, past_start, past_end))
       
         # "today"
         recurrence_id = intervals_since_start


### PR DESCRIPTION
- the recurring events are now created around today, it's not static anymore. 
- e.g: if we create a monthly event starting 11.03.2024, it'll return the past five (the limit for unliminted recurring events) events starting from today and five into the future
- recurrence_id is now the offset from the starting time of the base event to the generated instance


- easy enhancement if needed at some point: It'll be useful for frontend to pass a datetime object (if a user looks at his calendar a year into future or smth similar)